### PR TITLE
SCSt-GH-819: Sources: Resolve Channel at Runtime

### DIFF
--- a/spring-cloud-starter-stream-sink-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/sink/TcpSinkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class TcpSinkConfiguration {
 	private TcpSinkProperties properties;
 
 	@Bean
-	@ServiceActivator(inputChannel=Sink.INPUT)
+	@ServiceActivator(inputChannel = Sink.INPUT)
 	public TcpSendingMessageHandler handler(
 			@Qualifier("tcpSinkConnectionFactory") AbstractConnectionFactory connectionFactory) {
 		TcpSendingMessageHandler handler = new TcpSendingMessageHandler();

--- a/spring-cloud-starter-stream-source-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/source/TcpClientSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-tcp-client/src/main/java/org/springframework/cloud/stream/app/tcp/client/source/TcpClientSourceConfiguration.java
@@ -40,9 +40,6 @@ import org.springframework.integration.ip.tcp.serializer.AbstractByteArraySerial
 public class TcpClientSourceConfiguration {
 
 	@Autowired
-	private Source source;
-
-	@Autowired
 	private TcpClientSourceProperties properties;
 
 	@Bean
@@ -52,7 +49,7 @@ public class TcpClientSourceConfiguration {
 		adapter.setConnectionFactory(connectionFactory);
 		adapter.setClientMode(true);
 		adapter.setRetryInterval(this.properties.getRetryInterval());
-		adapter.setOutputChannel(this.source.output());
+		adapter.setOutputChannelName(Source.OUTPUT);
 		return adapter;
 	}
 

--- a/spring-cloud-starter-stream-source-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/source/TcpSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-tcp/src/main/java/org/springframework/cloud/stream/app/tcp/source/TcpSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,6 @@ import org.springframework.integration.ip.tcp.serializer.AbstractByteArraySerial
 public class TcpSourceConfiguration {
 
 	@Autowired
-	private Source channels;
-
-	@Autowired
 	private TcpSourceProperties properties;
 
 	@Bean
@@ -48,7 +45,7 @@ public class TcpSourceConfiguration {
 			@Qualifier("tcpSourceConnectionFactory") AbstractConnectionFactory connectionFactory) {
 		TcpReceivingChannelAdapter adapter = new TcpReceivingChannelAdapter();
 		adapter.setConnectionFactory(connectionFactory);
-		adapter.setOutputChannel(this.channels.output());
+		adapter.setOutputChannelName(Source.OUTPUT);
 		return adapter;
 	}
 

--- a/spring-cloud-starter-stream-source-tcp/src/test/java/org/springframework/cloud/stream/app/tcp/source/TcpSourceTests.java
+++ b/spring-cloud-starter-stream-source-tcp/src/test/java/org/springframework/cloud/stream/app/tcp/source/TcpSourceTests.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.app.tcp.source;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
+
+import java.net.Socket;
+
+import javax.net.SocketFactory;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.TcpNetServerConnectionFactory;
+import org.springframework.integration.ip.tcp.connection.TcpNioServerConnectionFactory;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Tests for TcpSource.
+ *
+ * @author Gary Russell
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+	properties = { "tcp.host = localhost", "tcp.port = 0" })
+public abstract class TcpSourceTests {
+
+	@Autowired
+	protected Source channels;
+
+	@Autowired
+	protected MessageCollector messageCollector;
+
+	@Autowired
+	protected AbstractServerConnectionFactory connectionFactory;
+
+	@Autowired
+	protected TcpSourceProperties properties;
+
+	@TestPropertySource(properties = { "tcp.nio = true", "tcp.reverseLookup = true",
+					"tcp.useDirectBuffers = true", "tcp.socketTimeout = 123", "tcp.bufferSize = 5" })
+	public static class PropertiesPopulatedTests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			assertThat(this.connectionFactory, Matchers.instanceOf(TcpNioServerConnectionFactory.class));
+			assertTrue(TestUtils.getPropertyValue(this.connectionFactory, "lookupHost", Boolean.class));
+			assertTrue(TestUtils.getPropertyValue(this.connectionFactory, "usingDirectBuffers", Boolean.class));
+			assertEquals(123, TestUtils.getPropertyValue(this.connectionFactory, "soTimeout"));
+			assertEquals(5, TestUtils.getPropertyValue(this.connectionFactory, "deserializer.maxMessageSize"));
+		}
+
+	}
+
+	public static class NotNioTests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			assertThat(this.connectionFactory, Matchers.instanceOf(TcpNetServerConnectionFactory.class));
+			assertFalse(TestUtils.getPropertyValue(this.connectionFactory, "lookupHost", Boolean.class));
+			assertEquals(120000, TestUtils.getPropertyValue(this.connectionFactory, "soTimeout"));
+			assertEquals(2048, TestUtils.getPropertyValue(this.connectionFactory, "deserializer.maxMessageSize"));
+		}
+
+	}
+
+	public static class CRLFTests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			doTest("", "foo", "\r\n");
+		}
+
+	}
+
+	@TestPropertySource(properties = { "tcp.decoder = LF" })
+	public static class LFTests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			doTest("", "foo", "\n");
+		}
+
+	}
+
+	@TestPropertySource(properties = { "tcp.decoder = NULL" })
+	public static class NULLTests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			doTest("", "foo", "\u0000");
+		}
+
+	}
+
+	@TestPropertySource(properties = { "tcp.decoder = STXETX" })
+	public static class STXETXTests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			doTest("\u0002", "foo", "\u0003");
+		}
+
+	}
+
+	@TestPropertySource(properties = { "tcp.decoder = L1" })
+	public static class L1Tests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			doTest("\u0003", "foo", "");
+		}
+
+	}
+
+	@TestPropertySource(properties = { "tcp.decoder = L2" })
+	public static class L2Tests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			doTest("\u0000\u0003", "foo", "");
+		}
+
+	}
+
+	@TestPropertySource(properties = { "tcp.decoder = L4" })
+	public static class L4Tests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			doTest("\u0000\u0000\u0000\u0003", "foo", "");
+		}
+
+	}
+
+	@TestPropertySource(properties = { "tcp.decoder = RAW" })
+	public static class RAWTests extends TcpSourceTests {
+
+		@Test
+		public void test() throws Exception {
+			doTest("", "foo", "");
+		}
+
+	}
+
+	/*
+	 * Sends two messages with <prefix><payload><suffix> and asserts the
+	 * payload is received on the other side.
+	 */
+	protected void doTest(String prefix, String payload, String suffix) throws Exception {
+		int port = getPort();
+		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
+		socket.getOutputStream().write((prefix + payload + suffix).getBytes());
+		if (prefix.length() == 0 && suffix.length() == 0) {
+			socket.close(); // RAW - for the others, close AFTER the messages are decoded.
+			socket = SocketFactory.getDefault().createSocket("localhost", port);
+		}
+		assertThat(this.messageCollector.forChannel(channels.output()), receivesPayloadThat(is(payload.getBytes())));
+		socket.getOutputStream().write((prefix + payload + suffix).getBytes());
+		if (prefix.length() == 0 && suffix.length() == 0) {
+			socket.close(); // RAW - for the others, close AFTER the messages are decoded.
+		}
+		assertThat(this.messageCollector.forChannel(channels.output()), receivesPayloadThat(is(payload.getBytes())));
+		socket.close();
+	}
+
+	private int getPort() throws Exception {
+		int n = 0;
+		while (n++ < 100 && !this.connectionFactory.isListening()) {
+			Thread.sleep(100);
+		}
+		assertTrue("server failed to start listening", this.connectionFactory.isListening());
+		int port = this.connectionFactory.getPort();
+		assertTrue("server stopped listening", port > 0);
+		return port;
+	}
+
+	@SpringBootApplication
+	public static class TcpSourceApplication {
+
+	}
+
+}


### PR DESCRIPTION
See spring-cloud/spring-cloud-stream#819

Resolve the channel at runtime to avoid auto wiring problems in aggregated apps.

Also, for some reason, the TcpSourceTests were not ported to the new repo.